### PR TITLE
Fix the installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You'll need to have [nodejs](http://nodejs.org/download/) installed before insta
 
 Currently SwaggerValidator is only available on the Pearson NPM server. Install with npm:
 
-    $ npm install swaggerValidator
+    $ npm install swagger-validator
 
 Basic Use
 ---------


### PR DESCRIPTION
The old instructions return this error:

```
$ npm install swaggerValidator
npm ERR! Darwin 13.4.0
npm ERR! argv "node" "/usr/local/bin/npm" "install" "swaggerValidator"
npm ERR! node v0.12.3
npm ERR! npm  v2.9.1
npm ERR! code E404

npm ERR! 404 Registry returned 404 for GET on https://registry.npmjs.org/swaggerValidator
npm ERR! 404 
npm ERR! 404 'swaggerValidator' is not in the npm registry.
```
